### PR TITLE
fix hooks使ってないので不要

### DIFF
--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -16,11 +16,6 @@ const config = {
 		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
 		// See https://svelte.dev/docs/kit/adapters for more information about adapters.
 		adapter: adapter(),
-		files: {
-			hooks: {
-				server: "src/lib/hooks/hooks.server.ts",
-			},
-		},
 	},
 };
 


### PR DESCRIPTION
```
The `config.kit.files.hooks.server` option is deprecated, and will be removed in a future version
Loading svelte-check in workspace: /frontend
Getting Svelte diagnostics...

The `config.kit.files.hooks.server` option is deprecated, and will be removed in a future version
```

だったが、そもそもhooksなんてもう使ってなかったので消す