### PR TITLE
Fix インデックスの処理でpanicになってる問題

### DIFF
--- a/backend/infrastructure/llm/gemini.go
+++ b/backend/infrastructure/llm/gemini.go
@@ -79,7 +79,7 @@ n日：箇条書き3
 		return "", fmt.Errorf("failed to generate content: %w", err)
 	}
 
-	if len(resp.Candidates) == 0 || len(resp.Candidates[0].Content.Parts) == 0 {
+	if len(resp.Candidates) == 0 || resp.Candidates[0].Content == nil || len(resp.Candidates[0].Content.Parts) == 0 {
 		return "", fmt.Errorf("no content generated")
 	}
 
@@ -125,7 +125,7 @@ func (g *GeminiClient) GenerateDailySummary(ctx context.Context, diaryContent st
 		return "", fmt.Errorf("failed to generate content: %w", err)
 	}
 
-	if len(resp.Candidates) == 0 || len(resp.Candidates[0].Content.Parts) == 0 {
+	if len(resp.Candidates) == 0 || resp.Candidates[0].Content == nil || len(resp.Candidates[0].Content.Parts) == 0 {
 		return "", fmt.Errorf("no content generated")
 	}
 
@@ -267,7 +267,7 @@ activities（活動・行動）:
 		return "", fmt.Errorf("failed to generate content: %w", err)
 	}
 
-	if len(resp.Candidates) == 0 || len(resp.Candidates[0].Content.Parts) == 0 {
+	if len(resp.Candidates) == 0 || resp.Candidates[0].Content == nil || len(resp.Candidates[0].Content.Parts) == 0 {
 		return "", fmt.Errorf("no content generated")
 	}
 
@@ -360,7 +360,7 @@ func (g *GeminiClient) SplitDiaryIntoChunks(ctx context.Context, content string)
 		return nil, fmt.Errorf("failed to split diary into chunks: %w", err)
 	}
 
-	if len(resp.Candidates) == 0 || len(resp.Candidates[0].Content.Parts) == 0 {
+	if len(resp.Candidates) == 0 || resp.Candidates[0].Content == nil || len(resp.Candidates[0].Content.Parts) == 0 {
 		return nil, fmt.Errorf("no content returned from chunk splitting")
 	}
 
@@ -465,7 +465,7 @@ func (g *GeminiClient) GenerateHighlights(ctx context.Context, diaryContent stri
 		return "", fmt.Errorf("failed to generate content: %w", err)
 	}
 
-	if len(resp.Candidates) == 0 || len(resp.Candidates[0].Content.Parts) == 0 {
+	if len(resp.Candidates) == 0 || resp.Candidates[0].Content == nil || len(resp.Candidates[0].Content.Parts) == 0 {
 		return "", fmt.Errorf("no content generated")
 	}
 

--- a/backend/infrastructure/llm/gemini.go
+++ b/backend/infrastructure/llm/gemini.go
@@ -16,6 +16,15 @@ const (
 	ModelEmbedding = "gemini-embedding-001"
 )
 
+// noSafetySettings は全カテゴリの安全フィルターを無効にする設定
+// 日記アプリでは個人の記録を正確に処理するためブロックなしとする
+var noSafetySettings = []*genai.SafetySetting{
+	{Category: genai.HarmCategoryHateSpeech, Threshold: genai.HarmBlockThresholdBlockNone},
+	{Category: genai.HarmCategoryDangerousContent, Threshold: genai.HarmBlockThresholdBlockNone},
+	{Category: genai.HarmCategorySexuallyExplicit, Threshold: genai.HarmBlockThresholdBlockNone},
+	{Category: genai.HarmCategoryHarassment, Threshold: genai.HarmBlockThresholdBlockNone},
+}
+
 // DiaryChunkData はLLMが生成したチャンクの内容と概要を保持する
 type DiaryChunkData struct {
 	// Content チャンクの元テキスト（ベクトル化対象）
@@ -71,7 +80,8 @@ n日：箇条書き3
 
 	zero := float32(0)
 	config := &genai.GenerateContentConfig{
-		Temperature: &zero,
+		Temperature:    &zero,
+		SafetySettings: noSafetySettings,
 	}
 
 	resp, err := g.client.Models.GenerateContent(ctx, ModelGenerateContent, contents, config)
@@ -117,7 +127,8 @@ func (g *GeminiClient) GenerateDailySummary(ctx context.Context, diaryContent st
 
 	zero := float32(0)
 	config := &genai.GenerateContentConfig{
-		Temperature: &zero,
+		Temperature:    &zero,
+		SafetySettings: noSafetySettings,
 	}
 
 	resp, err := g.client.Models.GenerateContent(ctx, ModelGenerateContent, contents, config)
@@ -260,6 +271,7 @@ activities（活動・行動）:
 	config := &genai.GenerateContentConfig{
 		ResponseMIMEType: "application/json",
 		ResponseSchema:   schema,
+		SafetySettings:   noSafetySettings,
 	}
 
 	resp, err := g.client.Models.GenerateContent(ctx, ModelGenerateContent, contents, config)
@@ -353,6 +365,7 @@ func (g *GeminiClient) SplitDiaryIntoChunks(ctx context.Context, content string)
 		Temperature:      &zero,
 		ResponseMIMEType: "application/json",
 		ResponseSchema:   schema,
+		SafetySettings:   noSafetySettings,
 	}
 
 	resp, err := g.client.Models.GenerateContent(ctx, ModelGenerateContent, contents, config)
@@ -458,6 +471,7 @@ func (g *GeminiClient) GenerateHighlights(ctx context.Context, diaryContent stri
 		Temperature:      &zero,
 		ResponseMIMEType: "application/json",
 		ResponseSchema:   schema,
+		SafetySettings:   noSafetySettings,
 	}
 
 	resp, err := g.client.Models.GenerateContent(ctx, ModelGenerateContent, contents, config)


### PR DESCRIPTION
contentがnilの時にpanicってた
```
subscriber-1  | panic: runtime error: invalid memory address or nil pointer dereference
subscriber-1  | [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xae25e8]
subscriber-1  |
subscriber-1  | goroutine 214219 [running]:
subscriber-1  | github.com/project-mikan/umi.mikan/backend/infrastructure/llm.(*GeminiClient).SplitDiaryIntoChunks(0x2b9bdbc6c1f8, {0x1454920, 0x2b9bdbdac3c0}, {0x2b9bdbdd4000?, 0x137fd80?})
subscriber-1  |         /build/infrastructure/llm/gemini.go:363 +0x548
subscriber-1  | main.generateDiaryEmbedding({0x1454920, 0x2b9bdbdac3c0}, 0x2b9bdbdd8dd0, {0x144b800, 0x1f90a40}, 0x2b9bdbdac320, {0x2b9bdc2264e0, 0x24}, {0x2b9bdc226510, 0x24}, ...)
subscriber-1  |         /build/cmd/subscriber/main.go:1151 +0x74b
subscriber-1  | main.processMessage({0x1454920, 0x2b9bdbdac3c0}, 0x2b9bdbdd8dd0, {0x1461640, 0x2b9bdbed4c30}, {0x144b800, 0x1f90a40}, {0x144b7e0, 0x2b9bdbc9e3f0}, 0x2b9bdbdac320, ...)
subscriber-1  |         /build/cmd/subscriber/main.go:421 +0xb05
subscriber-1  | main.runSubscriber.func3.1.1()
subscriber-1  |         /build/cmd/subscriber/main.go:247 +0x12e
subscriber-1  | created by main.runSubscriber.func3.1 in goroutine 49
subscriber-1  |         /build/cmd/subscriber/main.go:240 +0x39c
subscriber-1 exited with code 2 (restarting)
subscriber-1  | time="2026-04-09T13:42:20Z" level=info msg="=== umi.mikan subscriber started ===" service=subscriber
subscriber-1  | 2026/04/09 13:42:20 Database connection established: postgres:5432/umi_mikan
subscriber-1  | 2026/04/09 13:42:20 Redis connection established: redis:6379
subscriber-1  | time="2026-04-09T13:42:20Z" level=info msg="Connected to Redis successfully" service=subscriber
subscriber-1  | time="2026-04-09T13:42:20Z" level=info msg="Subscriber is listening for messages..." max_concurrent_jobs=1 service=subscriber
subscriber-1  | time="2026-04-09T13:42:20Z" level=info msg="Metrics server starting on :2005" service=subscriber
subscriber-1  | time="2026-04-09T13:42:20Z" level=info msg="Starting Redis Pub/Sub subscription..." service=subscriber
```