### PR TITLE
chore: PostgreSQL を 17 から 18 へアップグレード

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -45,7 +45,7 @@ services:
       - ./proto:/proto # 内部で解決できるようにマウント
 
   postgres:
-    image: pgvector/pgvector:0.7.4-pg17
+    image: pgvector/pgvector:0.8.2-pg18
     platform: linux/amd64
     environment:
       TZ: Asia/Tokyo
@@ -57,7 +57,7 @@ services:
       - ./schema:/docker-entrypoint-initdb.d
 
   postgres_test:
-    image: pgvector/pgvector:0.7.4-pg17
+    image: pgvector/pgvector:0.8.2-pg18
     platform: linux/amd64
     environment:
       TZ: Asia/Tokyo


### PR DESCRIPTION
pgvector/pgvector イメージを 0.7.4-pg17 から 0.8.2-pg18 に更新。
postgres・postgres_test の両サービスに適用。

https://claude.ai/code/session_01ULmBH1BMbZX47aZio8sRqA